### PR TITLE
Import fa locale file with its file extension

### DIFF
--- a/src/dayjs/plugin.ts
+++ b/src/dayjs/plugin.ts
@@ -1,6 +1,6 @@
 import type { PluginFunc } from 'dayjs'
 
-import fa from 'dayjs/locale/fa'
+import fa from 'dayjs/locale/fa.js'
 import jdate from '../calendar'
 import * as C from '../constant'
 


### PR DESCRIPTION
This pull request makes a minor update to the import statement for the Persian locale in the src/dayjs/plugin.ts file.
The change ensures that the correct module path is used when importing the locale.

I’m using `jalaliday` inside a `Nuxt 4` project combined with `Turborepo` (for monorepo management). When I try to use the plugin, I get the following error:
```
Cannot find module '/Users/mostafaznv/Projects/pname/frontend/node_modules/dayjs/locale/fa' imported from /Users/mostafaznv/Projects/pname/frontend/node_modules/jalaliday/dist/_chunks/plugin-DiTLeZtO.mjs 
Did you mean to import "dayjs/locale/fa.js"?
```

<img width="1723" height="456" alt="image" src="https://github.com/user-attachments/assets/a4a7933c-f224-4e3b-9ed0-5070371a13f6" />

<br><br>

After investigating, I found that explicitly importing the `fa` file with its .js extension resolves the issue.

I’m not sure if there are alternative workarounds that could solve this without updating the package itself. If there are, I’d greatly appreciate your suggestions.